### PR TITLE
Fix README run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
    pip install -r requirements.txt
    ```
 4. Запустите приложение:
-   ```bat
-    python finance_app/ui/main.py
-   ```
+    ```bat
+     python -m finance_app.ui.main
+    ```
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that the application should be run as a module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a65be7ccc8325a823cd9eb3784a8a